### PR TITLE
Fix a bug where Infinity speed causes the speed visualisation to break

### DIFF
--- a/static/js/visualizer.js
+++ b/static/js/visualizer.js
@@ -39,8 +39,10 @@ function getSpeedMax(allRoutes) {
     var sum = 0;
     var count = 0;
     for (var i = Math.floor(speeds.length * 0.94); i < speeds.length; i++) {
-        sum += speeds[i];
-        count++;
+        if(Number.isFinite(speeds[i])){
+            sum += speeds[i];
+            count++;
+        }
     }
 
     return Math.round(sum / count);


### PR DESCRIPTION
I ran into the issue that speed visualization didn't work properly (it only showed "Infinity" in the sidebar and all lines were blue).
The problem was that one of my datasets has an instance of `Infinity` speed at some point, so I added a condition to check if the speed is a finite number during `getSpeedMax()` and just ignore that entry if it is infinite. With this fix in place, the maximum speed is now calculated correctly and everything works as intended again.

Before the fix:
![grafik](https://github.com/oskarkraemer/komootHeatmap/assets/12248563/fc52ba9c-d8ef-4743-8aac-45498f2b9f6c)

After the fix:
![grafik](https://github.com/oskarkraemer/komootHeatmap/assets/12248563/d9dfe3f0-bbec-424d-8116-9494886a4097)

