### PR TITLE
added year visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ It **will not** be stored on any server. If you are still not comfortable with t
 	* ***Speed:*** Gradient from blue to red, indicating the speed at certain points
 	* ***Incline:*** Gradient from blue to red, indicating the incline in percent
 	* ***Elapsed Time:*** Shows how long you have already been on the tour at a certain point
+	* ***Year:*** Shows the year of the tour
 
 
 

--- a/static/css/button_group.css
+++ b/static/css/button_group.css
@@ -7,7 +7,7 @@
     float: left; /* Float the buttons side by side */
     border-radius: 4px;
     margin: 4px 8px 4px 0px;
-    width: 118px;
+    width: 130px;
 }
 
 /* Disabled button */

--- a/static/css/button_group.css
+++ b/static/css/button_group.css
@@ -6,7 +6,8 @@
     cursor: pointer; /* Pointer/hand icon */
     float: left; /* Float the buttons side by side */
     border-radius: 4px;
-    margin: 0px 4px 4px 4px;
+    margin: 4px 8px 4px 0px;
+    width: 118px;
 }
 
 /* Disabled button */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -12,3 +12,11 @@ html, body, #map {
 p {
     font-size: 14px;
 }
+
+.slider-container {
+    display: flex;
+    margin-top: 6px;
+    margin-bottom: 6px;
+    align-items: center; /* center slider and laber vertically */
+    height: 100%;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -17,6 +17,6 @@ p {
     display: flex;
     margin-top: 6px;
     margin-bottom: 6px;
-    align-items: center; /* center slider and laber vertically */
+    align-items: center; /* center slider and label vertically */
     height: 100%;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,15 +45,24 @@
                     <button id="speed" onclick="Visualizer.show_polylines(map, allRoutes, 'speed');">Speed</button>
                     <button id="incline" onclick="Visualizer.show_polylines(map, allRoutes, 'incline');">Incline</button>
                     <button id="elapsed" onclick="Visualizer.show_polylines(map, allRoutes, 'elapsed');">Elapsed Time</button>
+                    <button id="year" onclick="Visualizer.show_polylines(map, allRoutes, 'year');">Year</button>
                 </div>
-
-                <label for="line_range">Line width:</label>
-                <input type="range" min="1" max="6" value="4" step="1" class="slider" id="line_range">
+                <div class="slider-container">
+                    <label for="line_range">Line width:</label>
+                    <input type="range" min="1" max="6" value="4" step="1" class="slider" id="line_range">
+                </div>
 
                 <hr>
 
                 <div class='my-legend'>
                     <h3 class='custom-title' id="legend-label">Legend</h3>
+                    <div id="year-slider"  hidden="hidden">
+                        <div class="slider-container">
+                            <label for="start_year">Start year:</label>
+                            <input type="range" min="0" max="0" step="1" class="slider" id="start_year">
+                            <span id="start_year_value"></span>
+                        </div>
+                    </div>
                     <div class='legend-scale'>
                       <ul class='legend-labels'>
                         <li>-<span style='background:#0000FF;'></span></li>


### PR DESCRIPTION
Hallo oskarkraemer, 

vielen Dank für die tolle komootHeatmap! Das ich sehen kann, wo ich bereits war, hat mir bei Komoot schon lange gefehlt!

Ich habe die Funktionalität noch um eine zusätzliche Visualisierung erweitert. Man kann sich nun die Touren anhand der unterschiedlichen Jahre farblich anzeigen lassen. Über einen Slider kann man das Startjahr auswählen:

![image](https://github.com/user-attachments/assets/8eb74341-41a6-4ac6-bd6c-f399086f5ab3)

Evtl. ist das auch für andere Benutzer interessant?

Viele Grüße
Lars